### PR TITLE
テスト項目の修正#02

### DIFF
--- a/lib/pages/feed_page.dart
+++ b/lib/pages/feed_page.dart
@@ -78,7 +78,8 @@ class _FeedPageState extends State<FeedPage> {
                       ? CustomScrollView(
                           keyboardDismissBehavior:
                               ScrollViewKeyboardDismissBehavior.onDrag,
-                          physics: const AlwaysScrollableScrollPhysics(),
+                          physics: const BouncingScrollPhysics(
+                              parent: AlwaysScrollableScrollPhysics()),
                           slivers: [
                             CupertinoSliverRefreshControl(
                                 onRefresh: refreshArticle),
@@ -92,7 +93,8 @@ class _FeedPageState extends State<FeedPage> {
                           : CustomScrollView(
                               keyboardDismissBehavior:
                                   ScrollViewKeyboardDismissBehavior.onDrag,
-                              physics: const AlwaysScrollableScrollPhysics(),
+                              physics: const BouncingScrollPhysics(
+                                  parent: AlwaysScrollableScrollPhysics()),
                               slivers: [
                                 CupertinoSliverRefreshControl(
                                     onRefresh: refreshSearchWordArticle),

--- a/lib/pages/feed_page.dart
+++ b/lib/pages/feed_page.dart
@@ -78,7 +78,7 @@ class _FeedPageState extends State<FeedPage> {
                       ? CustomScrollView(
                           keyboardDismissBehavior:
                               ScrollViewKeyboardDismissBehavior.onDrag,
-                          physics: BouncingScrollPhysics(),
+                          physics: const AlwaysScrollableScrollPhysics(),
                           slivers: [
                             CupertinoSliverRefreshControl(
                                 onRefresh: refreshArticle),
@@ -92,7 +92,7 @@ class _FeedPageState extends State<FeedPage> {
                           : CustomScrollView(
                               keyboardDismissBehavior:
                                   ScrollViewKeyboardDismissBehavior.onDrag,
-                              physics: BouncingScrollPhysics(),
+                              physics: const AlwaysScrollableScrollPhysics(),
                               slivers: [
                                 CupertinoSliverRefreshControl(
                                     onRefresh: refreshSearchWordArticle),

--- a/lib/pages/follow_page.dart
+++ b/lib/pages/follow_page.dart
@@ -50,7 +50,7 @@ class _FollowPageState extends State<FollowPage> {
                   },
                   child: userList.isNotEmpty
                       ? CustomScrollView(
-                          physics: BouncingScrollPhysics(),
+                          physics: const AlwaysScrollableScrollPhysics(),
                           slivers: [
                             CupertinoSliverRefreshControl(
                                 onRefresh: refreshUser),

--- a/lib/pages/follow_page.dart
+++ b/lib/pages/follow_page.dart
@@ -50,7 +50,8 @@ class _FollowPageState extends State<FollowPage> {
                   },
                   child: userList.isNotEmpty
                       ? CustomScrollView(
-                          physics: const AlwaysScrollableScrollPhysics(),
+                          physics: const BouncingScrollPhysics(
+                              parent: AlwaysScrollableScrollPhysics()),
                           slivers: [
                             CupertinoSliverRefreshControl(
                                 onRefresh: refreshUser),

--- a/lib/pages/follow_page.dart
+++ b/lib/pages/follow_page.dart
@@ -29,6 +29,7 @@ class _FollowPageState extends State<FollowPage> {
 
   @override
   Widget build(BuildContext context) {
+    print(page);
     return Scaffold(
       appBar: AppBarComponent(
         text: 'Follows',
@@ -48,7 +49,15 @@ class _FollowPageState extends State<FollowPage> {
                     return false;
                   },
                   child: userList.isNotEmpty
-                      ? UserListView(userList: userList)
+                      ? CustomScrollView(
+                          physics: BouncingScrollPhysics(),
+                          slivers: [
+                            CupertinoSliverRefreshControl(
+                                onRefresh: refreshUser),
+                            SliverToBoxAdapter(
+                                child: UserListView(userList: userList)),
+                          ],
+                        )
                       : _isLoading
                           ? CupertinoActivityIndicator()
                           : EmptyView(),
@@ -69,6 +78,18 @@ class _FollowPageState extends State<FollowPage> {
     page++;
     userList.addAll(results);
     setState(() {
+      _isLoading = false;
+    });
+  }
+
+  Future<void> refreshUser() async {
+    page = 1;
+    _isLoading = true;
+    List<User> results =
+        await QiitaClient().getUserFollowees(page, widget.user.id);
+    page++;
+    setState(() {
+      userList = results;
       _isLoading = false;
     });
   }

--- a/lib/pages/follower_page.dart
+++ b/lib/pages/follower_page.dart
@@ -29,6 +29,7 @@ class _FollowerPageState extends State<FollowerPage> {
 
   @override
   Widget build(BuildContext context) {
+    print(page);
     return Scaffold(
       appBar: AppBarComponent(
         text: 'Followers',
@@ -48,7 +49,15 @@ class _FollowerPageState extends State<FollowerPage> {
                     return false;
                   },
                   child: userList.isNotEmpty
-                      ? UserListView(userList: userList)
+                      ? CustomScrollView(
+                          physics: BouncingScrollPhysics(),
+                          slivers: [
+                            CupertinoSliverRefreshControl(
+                                onRefresh: refreshUser),
+                            SliverToBoxAdapter(
+                                child: UserListView(userList: userList)),
+                          ],
+                        )
                       : _isLoading
                           ? CupertinoActivityIndicator()
                           : EmptyView(),
@@ -69,6 +78,18 @@ class _FollowerPageState extends State<FollowerPage> {
     page++;
     userList.addAll(results);
     setState(() {
+      _isLoading = false;
+    });
+  }
+
+  Future<void> refreshUser() async {
+    page = 1;
+    _isLoading = true;
+    List<User> results =
+        await QiitaClient().getUserFollowers(page, widget.user.id);
+    page++;
+    setState(() {
+      userList = results;
       _isLoading = false;
     });
   }

--- a/lib/pages/follower_page.dart
+++ b/lib/pages/follower_page.dart
@@ -50,7 +50,8 @@ class _FollowerPageState extends State<FollowerPage> {
                   },
                   child: userList.isNotEmpty
                       ? CustomScrollView(
-                          physics: const AlwaysScrollableScrollPhysics(),
+                          physics: const BouncingScrollPhysics(
+                              parent: AlwaysScrollableScrollPhysics()),
                           slivers: [
                             CupertinoSliverRefreshControl(
                                 onRefresh: refreshUser),

--- a/lib/pages/follower_page.dart
+++ b/lib/pages/follower_page.dart
@@ -50,7 +50,7 @@ class _FollowerPageState extends State<FollowerPage> {
                   },
                   child: userList.isNotEmpty
                       ? CustomScrollView(
-                          physics: BouncingScrollPhysics(),
+                          physics: const AlwaysScrollableScrollPhysics(),
                           slivers: [
                             CupertinoSliverRefreshControl(
                                 onRefresh: refreshUser),

--- a/lib/pages/tag_detail_page.dart
+++ b/lib/pages/tag_detail_page.dart
@@ -47,7 +47,8 @@ class _TagDetailPageState extends State<TagDetailPage> {
                   },
                   child: articleList.isNotEmpty
                       ? CustomScrollView(
-                          physics: const AlwaysScrollableScrollPhysics(),
+                          physics: const BouncingScrollPhysics(
+                              parent: AlwaysScrollableScrollPhysics()),
                           slivers: [
                             CupertinoSliverRefreshControl(
                                 onRefresh: refreshArticle),

--- a/lib/pages/tag_detail_page.dart
+++ b/lib/pages/tag_detail_page.dart
@@ -47,7 +47,7 @@ class _TagDetailPageState extends State<TagDetailPage> {
                   },
                   child: articleList.isNotEmpty
                       ? CustomScrollView(
-                          physics: BouncingScrollPhysics(),
+                          physics: const AlwaysScrollableScrollPhysics(),
                           slivers: [
                             CupertinoSliverRefreshControl(
                                 onRefresh: refreshArticle),

--- a/lib/pages/tag_page.dart
+++ b/lib/pages/tag_page.dart
@@ -45,7 +45,8 @@ class _TagPageState extends State<TagPage> {
                   },
                   child: tagList.isNotEmpty
                       ? CustomScrollView(
-                          physics: const AlwaysScrollableScrollPhysics(),
+                          physics: const BouncingScrollPhysics(
+                              parent: AlwaysScrollableScrollPhysics()),
                           slivers: [
                             CupertinoSliverRefreshControl(
                                 onRefresh: refreshTag),

--- a/lib/pages/tag_page.dart
+++ b/lib/pages/tag_page.dart
@@ -45,7 +45,7 @@ class _TagPageState extends State<TagPage> {
                   },
                   child: tagList.isNotEmpty
                       ? CustomScrollView(
-                          physics: BouncingScrollPhysics(),
+                          physics: const AlwaysScrollableScrollPhysics(),
                           slivers: [
                             CupertinoSliverRefreshControl(
                                 onRefresh: refreshTag),

--- a/lib/pages/top_page.dart
+++ b/lib/pages/top_page.dart
@@ -94,7 +94,7 @@ class _TopPageState extends State<TopPage> {
                           ),
                         ),
                         child: Text(
-                          'ログインする',
+                          'ログイン',
                           textAlign: TextAlign.center,
                           style: TextStyle(
                             fontStyle: FontStyle.normal,

--- a/lib/views/user_list_view.dart
+++ b/lib/views/user_list_view.dart
@@ -13,6 +13,7 @@ class UserListView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
       shrinkWrap: true,
       primary: false,
       itemCount: userList.length,

--- a/lib/views/user_list_view.dart
+++ b/lib/views/user_list_view.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
@@ -12,12 +13,14 @@ class UserListView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
+      shrinkWrap: true,
+      primary: false,
       itemCount: userList.length,
       itemBuilder: (BuildContext context, int index) {
         final user = userList[index];
         return index >= userList.length
             ? Center(
-                child: CircularProgressIndicator(),
+                child: CupertinoActivityIndicator(),
               )
             : GestureDetector(
                 child: Container(

--- a/lib/views/user_list_view.dart
+++ b/lib/views/user_list_view.dart
@@ -13,7 +13,6 @@ class UserListView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
-      physics: const AlwaysScrollableScrollPhysics(),
       shrinkWrap: true,
       primary: false,
       itemCount: userList.length,

--- a/lib/views/user_view/user_profile.dart
+++ b/lib/views/user_view/user_profile.dart
@@ -68,10 +68,11 @@ class UserProfile extends StatelessWidget {
               ),
               TextButton(
                   onPressed: () {
-                    Navigator.of(context)
-                        .push(MaterialWithModalsPageRoute(builder: (context) {
-                      return FollowPage(user);
-                    }));
+                    if (user.followeescount != 0)
+                      Navigator.of(context)
+                          .push(MaterialWithModalsPageRoute(builder: (context) {
+                        return FollowPage(user);
+                      }));
                   },
                   child: Text(
                     'フォロー中',
@@ -91,10 +92,11 @@ class UserProfile extends StatelessWidget {
               ),
               TextButton(
                   onPressed: () {
-                    Navigator.of(context)
-                        .push(MaterialWithModalsPageRoute(builder: (context) {
-                      return FollowerPage(user);
-                    }));
+                    if (user.followerscount != 0)
+                      Navigator.of(context)
+                          .push(MaterialWithModalsPageRoute(builder: (context) {
+                        return FollowerPage(user);
+                      }));
                   },
                   child: Text(
                     'フォロワー',

--- a/lib/views/user_view/user_view.dart
+++ b/lib/views/user_view/user_view.dart
@@ -50,7 +50,7 @@ class _UserViewState extends State<UserView> {
                       return true;
                     },
                     child: CustomScrollView(
-                        physics: BouncingScrollPhysics(),
+                        physics: const AlwaysScrollableScrollPhysics(),
                         slivers: [
                           CupertinoSliverRefreshControl(
                               onRefresh: refreshUserData),

--- a/lib/views/user_view/user_view.dart
+++ b/lib/views/user_view/user_view.dart
@@ -50,7 +50,8 @@ class _UserViewState extends State<UserView> {
                       return true;
                     },
                     child: CustomScrollView(
-                        physics: const AlwaysScrollableScrollPhysics(),
+                        physics: const BouncingScrollPhysics(
+                            parent: AlwaysScrollableScrollPhysics()),
                         slivers: [
                           CupertinoSliverRefreshControl(
                               onRefresh: refreshUserData),


### PR DESCRIPTION
テスト項目の修正の残りの
①FollowPageとFollowerPageのPull to refresh
②UserPageのフォロー数・フォロワー数が0のときタップしても何も起こらないようにする
を実装しました。

①は既に実装済みの他ページのPull to refreshと同じ方法で実装しました。